### PR TITLE
vision - Update chains.json

### DIFF
--- a/chains.json
+++ b/chains.json
@@ -3186,7 +3186,7 @@
     "nativeCurrency": {
       "name": "VS",
       "symbol": "VS",
-      "decimals": 6
+      "decimals": 18
     },
     "rpc": [
       "https://infragrid.v.network/ethereum/compatible"
@@ -3211,7 +3211,7 @@
     "nativeCurrency": {
       "name": "VS",
       "symbol": "VS",
-      "decimals": 6
+      "decimals": 18
     },
     "rpc": [
       "https://vpioneer.infragrid.v.network/ethereum/compatible"


### PR DESCRIPTION
decimals 6 --> 18

native vs decimal is 6 ,but ethereum compatible interface already adapt