### PR TITLE
Update Fusion Network RPC and Info (fsnscan.com)

### DIFF
--- a/chains.json
+++ b/chains.json
@@ -267,10 +267,10 @@
       "decimals": 18
     },
     "rpc": [
-      "https://mainnet.anyswap.exchange"
+      "https://mainnet.fusionnetwork.io"
     ],
     "faucets": [],
-    "infoURL": "https://fsnex.com/",
+    "infoURL": "https://fsnscan.com",
     "app_resource": {
       "ic_chain_select": "https://tp-upload.cdn.bcebos.com/v1/blockChain/Fusion/1.png",
       "ic_chain_unselect": "https://tp-upload.cdn.bcebos.com/v1/blockChain/Fusion/0.png",


### PR DESCRIPTION
This PR update the Fusion Network data from Fusion Foundation

RPC node update to https://mainnet.fusionnetwork.io
Info URL update to https://fsnscan.com