### PR TITLE
feat: add MCNChain to network list Update chains.json

### DIFF
--- a/chains.json
+++ b/chains.json
@@ -63492,8 +63492,16 @@
             "url": "https://block.mcnsmartchain.com",
             "standard": "EIP3091"
         }
-    ]
+    ],
+    "app_resource": {
+        "ic_chain_select": "https://photos.pinksale.finance/file/pinksale-logo-upload/1768216345304-4f17a2cc73fa22989e27cd2b22ec94bd.jpg",
+        "ic_chain_unselect": "https://photos.pinksale.finance/file/pinksale-logo-upload/1768216345304-4f17a2cc73fa22989e27cd2b22ec94bd.jpg",
+        "ic_chain_unselect_dark": "https://photos.pinksale.finance/file/pinksale-logo-upload/1768216345304-4f17a2cc73fa22989e27cd2b22ec94bd.jpg",
+        "color_chain_bg": "0x99FF00",
+        "color_chain_text": "0x000000",
+        "ic_home_logo": "https://photos.pinksale.finance/file/pinksale-logo-upload/1768216345304-4f17a2cc73fa22989e27cd2b22ec94bd.jpg"
+    }
 }
 
-
 ]
+

--- a/chains.json
+++ b/chains.json
@@ -63466,5 +63466,34 @@
             "ic_chain_unselect_dark": "http://icon.nexuschain.cc/night.png",
             "ic_home_logo": "http://icon.nexuschain.cc/night-m.png"
         }
-    }
+    },
+    {
+        "name": "MCNChain",
+        "chainId": 32169,
+        "shortName": "mcn",
+        "chain": "MCN",
+        "network": "mainnet",
+        "networkId": 32169,
+        "nativeCurrency": {
+            "name": "MCN",
+            "symbol": "MCN",
+                "decimals": 18
+    },
+    "rpc": [
+        "https://rpc1.mcnsmartchain.com",
+        "https://rpc2.mcnsmartchain.com",
+        "https://rpc3.mcnsmartchain.com"
+    ],
+    "faucets": [],
+    "infoURL": "https://www.mcnsmartchain.com",
+    "explorers": [
+        {
+            "name": "MCN Scan",
+            "url": "https://block.mcnsmartchain.com",
+            "standard": "EIP3091"
+        }
+    ]
+}
+
+
 ]


### PR DESCRIPTION
## Description
This PR adds the MCNChain network information to the `chains.json` file.

Network Details
- Network Name:MCNChain
- Chain ID: 32169
- Currency Symbol: MCN
- RPC URLs: 
  - https://rpc1.mcnsmartchain.com
  - https://rpc2.mcnsmartchain.com
  - https://rpc3.mcnsmartchain.com
- Block Explorer: https://block.mcnsmartchain.com
- Official Website: https://www.mcnsmartchain.com

I have verified the configuration and ensured it follows the repository's standard format. Please let me know if any further information or donation steps are required.
